### PR TITLE
Update subcompont generator. https://github.com/cmelion/generator-ng2-webpack/pull/43

### DIFF
--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -64,7 +64,8 @@ var Generator = module.exports = ComponentGenerator.extend({
                     this.destinationPath(path.join(destinationPath, 'spec.ts')), {
                         componentnameFile: this.componentnameFile,
                         componentname: this.componentname,
-                        componentnameClass: this.componentnameClass
+                        componentnameClass: this.componentnameClass,
+                        assertPath: path.relative(path.join(destinationPath, 'spec.ts'), path.join('src','app', 'assert')).replace(/\\/g,"/")                        
                     }
                 );
 

--- a/generators/component/templates/_component.spec.ts
+++ b/generators/component/templates/_component.spec.ts
@@ -2,22 +2,18 @@
 import {it, inject, beforeEachProviders} from '@angular/core/testing';
 import {TestComponentBuilder} from '@angular/compiler/testing';
 import {<%=componentnameClass%>Component} from './index';
+import {Assert} from '<%=assertPath%>';
 /* beautify ignore:end */
 
 describe('Component: <%=componentnameClass%>Component', () => {
 
-    beforeEachProviders(() => []);
+    let providers = [];      
+    let assert = new Assert<<%=componentnameClass%>Component>(<%=componentnameClass%>Component, providers);   
+  
+    assert.it('should be defined', (component, element, fixture) => {
+        fixture.detectChanges();
 
-    it('should be defined', inject([TestComponentBuilder], (tcb) => {
-        return tcb.createAsync(<%=componentnameClass%>Component)
-            .then((fixture) => {            
-                let element = fixture.debugElement.nativeElement;
-                let cmpInstance = <<%=componentnameClass%>Component>fixture.debugElement.componentInstance;
-                fixture.detectChanges();
-
-                expect(cmpInstance).toBeDefined();
-                expect(element).toBeDefined();
-            });
-    }));
-
+        expect(component).toBeDefined();
+        expect(element).toBeDefined();
+    });
 });


### PR DESCRIPTION
Using .replace(/\\/g,"/") to ensure forward slashes are used for paths on Windows machines.